### PR TITLE
Adding iocextract and domain_stats 

### DIFF
--- a/repo-list.yaml
+++ b/repo-list.yaml
@@ -1076,4 +1076,3 @@ repos:
   - threat-intelligence
   - threat-hunting
   contributor_name: zendannyy
-  

--- a/repo-list.yaml
+++ b/repo-list.yaml
@@ -1064,3 +1064,16 @@ repos:
   - threat-hunting
   - rust
   contributor_name: darkquasar
+- repo_url: https://github.com/InQuest/iocextract
+  tags:
+  - defensive-tradecraft
+  - threat-intelligence
+  - threat-hunting
+  contributor_name: zendannyy
+- repo_url: https://github.com/MarkBaggett/domain_stats
+  tags:
+  - defensive-tradecraft
+  - threat-intelligence
+  - threat-hunting
+  contributor_name: zendannyy
+  


### PR DESCRIPTION
These projects are good for use cases around defanging ioc's from a list, threat feed, etc. and getting threat related data on domains, respectively 